### PR TITLE
Improve translator page styling

### DIFF
--- a/shiny-translate/app.py
+++ b/shiny-translate/app.py
@@ -3,17 +3,20 @@ from Bio.Seq import Seq
 
 app_ui = ui.page_fluid(
     ui.include_css("www/styles.css"),
-    ui.h2("DNA/RNA to Protein Translator"),
-    ui.p("Paste your DNA or RNA sequence below:"),
-    ui.input_text_area(
-        "sequence",
-        label="",
-        placeholder="Enter DNA or RNA sequence here",
-        rows=6,
+    ui.div(
+        ui.h2("DNA/RNA to Protein Translator"),
+        ui.p("Paste your DNA or RNA sequence below:"),
+        ui.input_text_area(
+            "sequence",
+            label="",
+            placeholder="Enter DNA or RNA sequence here",
+            rows=6,
+        ),
+        ui.br(),
+        ui.h4("Translated Protein:"),
+        ui.output_text_verbatim("protein_output"),
+        class_="translator-card",
     ),
-    ui.br(),
-    ui.h4("Translated Protein:"),
-    ui.output_text_verbatim("protein_output"),
     ui.tags.footer(
         ui.p(
             "Powered by Biopython & Shiny for Python",

--- a/shiny-translate/www/styles.css
+++ b/shiny-translate/www/styles.css
@@ -1,20 +1,37 @@
 body {
-    background-color: #f8f9fa;
-    font-family: Arial, sans-serif;
+    background: linear-gradient(to right, #f8f9fa, #e9ecef);
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
-    padding: 20px;
+    padding: 40px;
+    display: flex;
+    justify-content: center;
+    min-height: 100vh;
 }
 
 h2 {
     color: #2c3e50;
     text-align: center;
+    margin-top: 0;
     margin-bottom: 20px;
+    font-weight: 600;
+}
+
+.translator-card {
+    background-color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    padding: 30px;
+    max-width: 700px;
+    width: 100%;
 }
 
 textarea {
     font-family: monospace;
     width: 100%;
     border-radius: 4px;
+    border: 1px solid #ced4da;
+    padding: 10px;
+    box-sizing: border-box;
 }
 
 #protein_output {
@@ -24,4 +41,5 @@ textarea {
     border: 1px solid #ced4da;
     padding: 10px;
     border-radius: 4px;
+    min-height: 60px;
 }


### PR DESCRIPTION
## Summary
- add `translator-card` container in app layout
- redesign stylesheet with gradient background and card layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68755e471fec8331a38f7e45bd1fad69