### PR TITLE
Add side-by-side layout for translator

### DIFF
--- a/shiny-translate/app.py
+++ b/shiny-translate/app.py
@@ -5,16 +5,25 @@ app_ui = ui.page_fluid(
     ui.include_css("www/styles.css"),
     ui.div(
         ui.h2("DNA/RNA to Protein Translator"),
-        ui.p("Paste your DNA or RNA sequence below:"),
-        ui.input_text_area(
-            "sequence",
-            label="",
-            placeholder="Enter DNA or RNA sequence here",
-            rows=6,
+        ui.div(
+            ui.div(
+                ui.p("Paste your DNA or RNA sequence below:"),
+                ui.input_text_area(
+                    "sequence",
+                    label="",
+                    placeholder="Enter DNA or RNA sequence here",
+                    rows=6,
+                ),
+                class_="input-section",
+            ),
+            ui.div("\u2192", class_="arrow"),
+            ui.div(
+                ui.h4("Translated Protein:"),
+                ui.output_text_verbatim("protein_output"),
+                class_="output-section",
+            ),
+            class_="translator-container",
         ),
-        ui.br(),
-        ui.h4("Translated Protein:"),
-        ui.output_text_verbatim("protein_output"),
         class_="translator-card",
     ),
     ui.tags.footer(

--- a/shiny-translate/www/styles.css
+++ b/shiny-translate/www/styles.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap');
+
 body {
     background: linear-gradient(to right, #f8f9fa, #e9ecef);
-    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Roboto Slab', Arial, sans-serif;
     margin: 0;
     padding: 40px;
     display: flex;
@@ -21,8 +23,28 @@ h2 {
     border-radius: 8px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     padding: 30px;
-    max-width: 700px;
+    max-width: 900px;
     width: 100%;
+}
+
+.translator-container {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.input-section,
+.output-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.arrow {
+    font-size: 2rem;
+    text-align: center;
+    padding-top: 40px;
+    color: #2c3e50;
 }
 
 textarea {


### PR DESCRIPTION
## Summary
- restyle app with Roboto Slab font and side-by-side layout
- adjust CSS for translator look and arrow indicator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6875edf8c9988331ae1cf8854463547d